### PR TITLE
Bump libray version to non-beta

### DIFF
--- a/.github/workflows/test-dotnet-versions.yml
+++ b/.github/workflows/test-dotnet-versions.yml
@@ -50,11 +50,3 @@ jobs:
         with:
           name: nupkg
           path: 'src/Dynatrace.MetricUtils/bin/Release/*.*nupkg'
-  
-  all-passed:
-    needs:
-      - build-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: All checks passed
-        run: 'true'

--- a/.github/workflows/test-dotnet-versions.yml
+++ b/.github/workflows/test-dotnet-versions.yml
@@ -58,4 +58,3 @@ jobs:
     steps:
       - name: All checks passed
         run: 'true'
-        

--- a/.github/workflows/test-dotnet-versions.yml
+++ b/.github/workflows/test-dotnet-versions.yml
@@ -58,3 +58,4 @@ jobs:
     steps:
       - name: All checks passed
         run: 'true'
+        

--- a/.github/workflows/test-dotnet-versions.yml
+++ b/.github/workflows/test-dotnet-versions.yml
@@ -50,3 +50,11 @@ jobs:
         with:
           name: nupkg
           path: 'src/Dynatrace.MetricUtils/bin/Release/*.*nupkg'
+  
+  all-passed:
+    needs:
+      - build-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: All checks passed
+        run: 'true'

--- a/.github/workflows/test-dotnet-versions.yml
+++ b/.github/workflows/test-dotnet-versions.yml
@@ -2,7 +2,7 @@ name: .NET Build and Test
 
 on:
   push:
-      branches: [ main ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
   # allows manually triggering the build.
@@ -11,12 +11,11 @@ on:
 jobs:
   build-test:
     strategy:
-      matrix: 
-        os: [
-          ubuntu-latest,
-          windows-latest,
-          macos-latest
-        ]
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
     
     runs-on: ${{ matrix.os }}
     
@@ -44,7 +43,7 @@ jobs:
       - name: Package library
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: dotnet pack src/Dynatrace.MetricUtils --configuration Release --no-build
-       
+
       - name: Archive nupkg
         if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: actions/upload-artifact@v2

--- a/src/Dynatrace.MetricUtils/Dynatrace.MetricUtils.csproj
+++ b/src/Dynatrace.MetricUtils/Dynatrace.MetricUtils.csproj
@@ -5,7 +5,7 @@
     <Company>Dynatrace LLC</Company>
     <Product>Dynatrace Metrics Utils for .NET</Product>
     <PackageId>Dynatrace.MetricUtils</PackageId>
-    <Version>0.3.0-beta</Version>
+    <Version>0.3.0</Version>
     <Description>See https://github.com/dynatrace-oss/dynatrace-metric-utils-dotnet#readme to learn more.</Description>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Copyright>Copyright 2021 Dynatrace LLC; Licensed under the Apache License, Version 2.0</Copyright>


### PR DESCRIPTION
Bumping library version to 0.3.0 so we can release a non-beta version for the release of the OpenTelemetry metrics exporter. 
Warning in the build: 
```
Warning: /home/runner/.dotnet/sdk/6.0.300/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5): warning NU5104: A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "Dynatrace.MetricUtils [0.2.0-beta, )" or update the version field in the nuspec. [/home/runner/work/opentelemetry-metric-dotnet/opentelemetry-metric-dotnet/src/Dynatrace.OpenTelemetry.Exporter.Metrics/Dynatrace.OpenTelemetry.Exporter.Metrics.csproj]
```