### PR TITLE
Update dependencies for `Dynatrace.MetricUtils.Example`

### DIFF
--- a/src/Dynatrace.MetricUtils.Example/Dynatrace.MetricUtils.Example.csproj
+++ b/src/Dynatrace.MetricUtils.Example/Dynatrace.MetricUtils.Example.csproj
@@ -6,6 +6,6 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/Dynatrace.MetricUtils/Dynatrace.MetricUtils.csproj" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates `Microsoft.Extensions.Logging.Console` to `6.0.0` in `Dynatrace.MetricUtils.Example`